### PR TITLE
Use bootstrap versions

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,14 @@
     "angular-mocks": "1.2.21",
     "angular-scenario": "1.2.21"
   },
+  "overrides": {
+    "angular-formly": {
+      "main": [
+        "dist/formly.bootstrap.min.js",
+        "dist/formly.bootstrap.map.js"
+      ]
+    }  
+  },
   "appPath": "client/app/",
   "resolutions": {
     "angular": "1.2.21"


### PR DESCRIPTION
Overrides to use bootstrap version of formly. see: https://github.com/taptapship/wiredep
