### PR TITLE
Update grunt-connect-proxy to v0.2.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "grunt-autoprefixer": "^2.2.0",
     "grunt-cli": "^0.1.13",
     "grunt-concurrent": "^1.0.0",
-    "grunt-connect-proxy": "^0.1.11",
+    "grunt-connect-proxy": "^0.2.0",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-concat": "^0.5.0",
     "grunt-contrib-connect": "^0.9.0",


### PR DESCRIPTION
Fixes grunt build error (#68).