### PR TITLE
Fix bug for social authentication

### DIFF
--- a/client/app/modules/core/controllers/main.ctrl.js
+++ b/client/app/modules/core/controllers/main.ctrl.js
@@ -13,10 +13,12 @@
  **/
 angular.module('com.module.core')
   .controller('MainCtrl', function($scope, $rootScope, $state, $location,
-    CoreService, User, gettextCatalog) {
+    CoreService, User, gettextCatalog, AppAuth) {
 
-
-    $scope.currentUser = User.getCurrent();
+	AppAuth.ensureHasCurrentUser(function(user)
+    {
+      $scope.currentUser = user;
+	});
 
     $scope.menuoptions = $rootScope.menu;
 


### PR DESCRIPTION
I was not able to connect using social login because User.getCurrent() was returning unauthorized error. AppAuth.ensureHasCurrentUser finalize the user connexion.
Best,
Thibaut
