### PR TITLE
Fix logout by checking if a user is still logged in after setting token

### DIFF
--- a/apps/admin/src/app/app.service.ts
+++ b/apps/admin/src/app/app.service.ts
@@ -40,6 +40,7 @@ export class AppService {
       this.store.dispatch({ type: 'APP_DOMAIN_SET', payload: JSON.parse(window.localStorage.getItem('domain'))})
     }
     if (window.localStorage.getItem('token')) {
+      this.store.dispatch({ type: 'AUTH_CHECK_TOKEN' })
       this.store.dispatch({ type: 'AUTH_SET_TOKEN', payload: JSON.parse(window.localStorage.getItem('token'))})
     }
     if (window.localStorage.getItem('roles')) {

--- a/modules/admin-auth/src/state/auth.actions.ts
+++ b/modules/admin-auth/src/state/auth.actions.ts
@@ -16,6 +16,9 @@ export const ActionTypes = {
   AUTH_REGISTER:              'AUTH_REGISTER',
   AUTH_REGISTER_ERROR:        'AUTH_REGISTER_ERROR',
   AUTH_REGISTER_SUCCESS:      'AUTH_REGISTER_SUCCESS',
+  AUTH_CHECK_TOKEN:           'AUTH_CHECK_TOKEN',
+  AUTH_CHECK_TOKEN_ERROR:     'AUTH_CHECK_TOKEN_ERROR',
+  AUTH_CHECK_TOKEN_SUCCESS:   'AUTH_CHECK_TOKEN_SUCCESS',
 }
 
 type credentials = {
@@ -94,6 +97,20 @@ export class AuthRegisterSuccessAction implements Action {
   constructor(public payload: any) { }
 }
 
+/** AUTH_CHECK_TOKEN **/
+export class AuthCheckTokenAction implements Action {
+  type = ActionTypes.AUTH_CHECK_TOKEN
+  constructor(public payload: any) { }
+}
+export class AuthCheckTokenErrorAction implements Action {
+  type = ActionTypes.AUTH_CHECK_TOKEN_ERROR
+  constructor(public payload: any) { }
+}
+export class AuthCheckTokenSuccessAction implements Action {
+  type = ActionTypes.AUTH_CHECK_TOKEN_SUCCESS
+  constructor(public payload: any) { }
+}
+
 export type Actions
   = AuthLoginAction
   | AuthLoginErrorAction
@@ -110,3 +127,6 @@ export type Actions
   | AuthRegisterAction
   | AuthRegisterErrorAction
   | AuthRegisterSuccessAction
+  | AuthCheckTokenAction
+  | AuthCheckTokenErrorAction
+  | AuthCheckTokenSuccessAction

--- a/modules/admin-auth/src/state/auth.effects.ts
+++ b/modules/admin-auth/src/state/auth.effects.ts
@@ -112,6 +112,32 @@ export class AuthEffects {
         })
     })
 
+  @Effect({ dispatch: false })
+  checkToken: Observable<Action> = this.actions$
+    .ofType(auth.ActionTypes.AUTH_CHECK_TOKEN)
+    .do(() => this.userApi.getCurrent()
+      .subscribe(
+        (success) => this.store.dispatch(new auth.AuthCheckTokenSuccessAction(success)),
+        (error) => this.store.dispatch(new auth.AuthCheckTokenErrorAction(error)),
+      )
+    )
+
+  @Effect({ dispatch: false })
+  checkTokenError: Observable<Action> = this.actions$
+    .ofType(auth.ActionTypes.AUTH_CHECK_TOKEN_ERROR)
+    .do((action) => {
+      this.ui.toastError('Invalid Token', 'Redirecting to login screen')
+      return this.store.dispatch({ type: 'APP_REDIRECT_LOGIN' })
+    })
+
+  @Effect({ dispatch: false })
+  checkTokenSuccess: Observable<Action> = this.actions$
+    .ofType(auth.ActionTypes.AUTH_CHECK_TOKEN_SUCCESS)
+    .do(() => {
+      this.ui.toastSuccess('Valid Token', 'It all looks good :)')
+      return true
+    })
+
   constructor(
     private actions$: Actions,
     private store: Store<any>,

--- a/modules/admin-core/src/router/router.component.ts
+++ b/modules/admin-core/src/router/router.component.ts
@@ -1,22 +1,20 @@
-import { Component } from '@angular/core'
+import { Component, OnInit } from '@angular/core'
 import { Store } from '@ngrx/store'
 
 @Component({
   template: `<ui-message [message]="'Redirecting.'"></ui-message>`,
 })
-export class RouterComponent {
+export class RouterComponent implements OnInit {
 
   constructor(
     private store: Store<any>,
-  ) {
+  ) { }
+
+  ngOnInit() {
     this.store
       .select('auth')
       .subscribe((res: any) => {
-        console.log('res', res)
-        if (res.loggedIn) {
-          return this.store.dispatch({ type: 'APP_REDIRECT_DASHBOARD' })
-        }
-        return this.store.dispatch({ type: 'APP_REDIRECT_LOGIN' })
+        return this.store.dispatch({ type: res.loggedIn ? 'APP_REDIRECT_DASHBOARD' : 'APP_REDIRECT_LOGIN' })
       })
   }
 }

--- a/modules/api-system/common/models/system-user.json
+++ b/modules/api-system/common/models/system-user.json
@@ -88,7 +88,7 @@
       "accessType": "READ",
       "principalType": "ROLE",
       "principalId": "$unauthenticated",
-      "permission": "ALLOW"
+      "permission": "DENY"
     },
     {
       "accessType": "READ",


### PR DESCRIPTION
### Description

- The SystemUser ACL should not allow reading user data for unauthenticated users
- The AccessToken should be verified after it's been set from local storage

