### PR TITLE
feat(api): add npm run initdb command

### DIFF
--- a/apps/api/bin/initdb.js
+++ b/apps/api/bin/initdb.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+process.env.INITDB = true
+process.env.MIGRATEDB = true
+
+const app = require('../server/server')
+
+app.on('booted', process.exit)

--- a/apps/api/config/custom-environment-variables.yaml
+++ b/apps/api/config/custom-environment-variables.yaml
@@ -23,3 +23,4 @@ storage:
 
 system:
   initdb: INITDB
+  migratedb: MIGRATEDB

--- a/apps/api/config/default.yaml
+++ b/apps/api/config/default.yaml
@@ -23,3 +23,4 @@ storage:
 
 system:
   initdb: false
+  migratedb: false

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -27,6 +27,7 @@
     "clean": "rimraf ./client/*",
     "build": "npm run clean && cp -rv ../admin/dist/* ./client/",
     "dev": "nodemon",
+    "initdb": "node bin/initdb",
     "start": "node .",
     "test": "true"
   },

--- a/apps/api/server/boot/99-db-migrate-update.js
+++ b/apps/api/server/boot/99-db-migrate-update.js
@@ -7,8 +7,8 @@ const { dbMigrate, dbUpdate } = require('@colmena/api-helpers')
 module.exports = function(app, cb) {
 
   // Check if there is user configured Settings
-  if (!config.has('system.initdb') || config.get('system.initdb') === false) {
-    log.gray.b('[db-migrate] skipping database migration (initdb = false)')
+  if (!config.has('system.migratedb') || config.get('system.migratedb') === false) {
+    log.gray.b('[db-migrate] skipping database migration (migratedb = false)')
     return cb()
   }
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "dev": "lerna run dev --stream",
     "dev:admin": "lerna run dev --stream --scope @colmena/admin",
     "dev:api": "lerna run dev --stream --scope @colmena/api",
+    "initdb": "cd apps/api && node bin/initdb",
     "servers": "npm run servers:start",
     "servers:logs": "docker-compose logs -f",
     "servers:start": "docker-compose up -d",


### PR DESCRIPTION
### Description

Allow user to run `npm run initdb` for one-off resetting/loading the db. 