### PR TITLE
feat: use bin/clean script to clean up the whole project

### DIFF
--- a/bin/clean.js
+++ b/bin/clean.js
@@ -1,16 +1,4 @@
 #!/usr/bin/env node
-const { clean, pJoin } = require('./lib/functions')
+const { clean } = require('./lib/functions')
 
-const pJson = require('../package.json')
-const packageName = '@colmena/colmena'
-const projectPath = pJoin(__dirname, '..')
-
-if (!pJson || !pJson.name || pJson.name !== packageName) {
-  console.log(`Could not find the ${packageName} project`)
-  process.emit(1)
-}
-console.log(`[clean] Removing node_modules from project path ${projectPath}`)
-
-clean(projectPath)
-
-console.log('[clean] Done.')
+clean()

--- a/bin/lib/functions.js
+++ b/bin/lib/functions.js
@@ -1,8 +1,6 @@
 const fs = require('fs')
 const path = require('path')
 
-const pJoin = (p, f) => path.join(p, f)
-
 /**
  * Synchronously check if path exists
  * @param p the path to check
@@ -14,7 +12,17 @@ const exists = p => fs.existsSync(p)
  * @param p the dir to read
  * @returns array A list of dir names
  */
-const getDirectories = p => readDir(p).filter(f => isDir(pJoin(p, f)))
+const getDirectories = p => readDir(p).filter(f => isDir(path.join(p, f)))
+
+/**
+ * Synchronously get a list of directories in a dir
+ * @param p the dir to read
+ * @returns array A list of dir names
+ */
+const getDirectoriesFilter = (p, filter) =>
+  getDirectories(p)
+    .filter(dir => dir === filter)
+    .map(item => path.join(p, item))
 
 /**
  * Synchronously check if path is a dir
@@ -48,25 +56,63 @@ const rmFile = f => fs.unlinkSync(f)
 const rmDirRecursive = p => {
   if (!exists(p)) return
   readDir(p)
-    .map(dirs => pJoin(p, dirs))
+    .map(dirs => path.join(p, dirs))
     .map(item => (isDir(item) ? rmDirRecursive(item) : rmFile(item)))
   rmDir(p)
 }
 
+const getProjectPath = () => {
+  const projectName = '@colmena/colmena'
+  const projectRoot = '../..'
+  const projectPath = path.join(__dirname, projectRoot)
+
+  const pjson = require(`${projectPath}/package.json`)
+
+  if (!pjson || !pjson.name || pjson.name !== projectName) {
+    console.log(`Could not find the ${projectName} project`)
+    return process.exit(1)
+  }
+  return projectPath
+}
+
+const getLernaPaths = p => {
+  const lerna = ['apps', 'modules', 'packages']
+
+  const paths = []
+
+  lerna.forEach(dir => {
+    const dirPath = path.join(p, dir)
+    const lernaDirs = getDirectories(dirPath).map(d => path.join(dirPath, d))
+    paths.push(...lernaDirs)
+  })
+
+  return paths
+}
+
+const hasSubDir = (p, filter) =>
+  p
+    .map(dir => getDirectoriesFilter(dir, filter))
+    .filter(item => item.length)
+    .map(item => item[0])
+
 /**
  * Clean the node_modules dir from a path
- * @param p the dir to remove
  */
-const clean = p =>
-  getDirectories(p)
-    .filter(dir => dir === 'node_modules')
-    .map(dir => pJoin(p, dir))
-    .map(dir => {
-      console.log(`[!] Removing ${dir}`)
-      rmDirRecursive(dir)
-    })
+const clean = () => {
+  const p = getProjectPath()
+
+  console.log(`[clean] Cleaning up project path ${p}`)
+
+  const paths = [p, ...getLernaPaths(p)]
+
+  hasSubDir(paths, 'node_modules').forEach(dir => {
+    console.log(`[clean] Remove ${dir}`)
+    rmDirRecursive(dir)
+  })
+
+  console.log('[clean] Done.')
+}
 
 module.exports = {
-  pJoin,
   clean,
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "admin"
   ],
   "scripts": {
-    "clean": "lerna clean --yes && node bin/clean",
+    "clean": "node bin/clean",
     "clean:api": "cd apps/api && npm run clean",
     "clean:admin": "cd apps/admin && npm run clean",
     "console": "cd apps/api && loopback-console server/server.js",


### PR DESCRIPTION
### Description

My root `node_modules` folder ran into an invalid state and `lerna clean` no longer worked. 

This PR updates `bin/clean` to remove all the `node_modules` in the monorepo.

@brannon-darby can you please test this on Windows? Thanks!