### PR TITLE
fix: user reset password failed

### DIFF
--- a/modules/api/system/common/models/system-user/user.password-reset.js
+++ b/modules/api/system/common/models/system-user/user.password-reset.js
@@ -10,19 +10,22 @@ module.exports = function userPasswordReset(User) {
    */
   const _resetPassword = User.resetPassword
 
-  User.resetPassword = function resetPassword(options) {
+  User.resetPassword = function resetPassword(options, cb) {
     return _resetPassword.call(User, options, err => {
       // Limit the information we reveal.
       if (err && err.code !== 'EMAIL_NOT_FOUND') {
-        return Promise.reject(err)
+        return cb(err)
       }
-      return Promise.resolve()
+      return cb()
     })
   }
 
   User.sendPasswordResetMessage = function sendPasswordResetMessage(ctx) {
     // We first retrieve the domain based on the realm to get the reply-to email and name
-    return User.app.models.Domain
+    if (ctx.user.realm === undefined || ctx.user.realm === null) {
+      ctx.user.realm = 'default'
+    }
+    return User.app.models.SystemDomain
       .findById(ctx.user.realm)
       .then(domain => {
         // This is the access token we will send to the user


### PR DESCRIPTION
### Description
Fix user reset password failed 
![image](https://user-images.githubusercontent.com/1614117/32359388-b31394b8-c088-11e7-8186-0cf123f876ae.png)![

First, `User.app.models.Domain` is undefined in function `User.sendPasswordResetMessage` in user.password-reset.js
Second, no response from server after post http request `/users/reset`



