### PR TITLE
fix(api-helpers): getGravatarUrl() Error when POST /api/v1/Users/reset-password

### DIFF
--- a/packages/api-helpers/src/gravatar.js
+++ b/packages/api-helpers/src/gravatar.js
@@ -6,6 +6,6 @@ const gravatarUrl = 'http://www.gravatar.com/avatar/'
 const gravatarSize = 150
 
 const getGravatarUrl = email =>
-  `${gravatarUrl}${getHash(email)}?s=${gravatarSize}`
+  email instanceof String ? `${gravatarUrl}${getHash(email)}?s=${gravatarSize}` : ''
 
 module.exports = { getGravatarUrl }


### PR DESCRIPTION
`getAvatarUrl()` Error when POST `/api/v1/Users/reset-password`
I add some debug logs in @colmena/api  `getAvatarUrl()`:
`
@colmena/api: getAvatarUrl() item= { password: '$2a$10$Tjq1mljjUYgQLmQhxeo2QOJsAFuvYlYEfBkPsCVPfQOuHn2vqR5/i',
@colmena/api:   modified: 2017-11-05T15:09:48.836Z }
@colmena/api: Unhandled error for request POST /api/v1/Users/reset-password: TypeError: Data must be a string or a buffer\n    at TypeError (native)\n    at Hash.update (crypto.js:74:16)\n    at getHash (/Users/caster/work/cecep/foresight/packages/api-helpers/src/gravatar.js:3:49)\n    at getGravatarUrl (/Users/caster/work/cecep/foresight/packages/api-helpers/src/gravatar.js:9:20)\n    at Function.SystemUser.getAvatarUrl.item [as getAvatarUrl] (/Users/caster/work/cecep/foresight/modules/api/system/common/models/system-user/user.computed.js:8:40)\n    at Promise.map.property (/Users/caster/work/cecep/foresight/apps/api/node_modules/loopback-ds-computed-mixin/lib/computed.js:41:33)\n    at runCallback (timers.js:666:20)\n    at tryOnImmediate (timers.js:639:5)\n    at processImmediate [as _immediateCallback] (timers.js:611:5)
`


### Description


#### Related issues

<!--
Please use the following link syntaxes:

- #42 (to reference issues in the current repository)
- colmena/colmena#42 (to reference issues in another repository)
-->

- None

<!--
Please mark your choice with an "x" (i.e. [x], see
-->


<!--
Thanks to strongloop/loopback for this template
-->
