### PR TITLE
fix: command 'npm run sdk'

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "servers:rm": "npm run servers:stop && docker-compose rm -f",
     "lint": "prettier --write",
     "sdk": "npm run sdk:api",
-    "sdk:api": "cross-env NODE_ENV=codegen lb-sdk --wipe enabled server/server.js ../../packages/admin-lb-sdk/src",
+    "sdk:api":
+      "cross-env NODE_ENV=codegen ts-node  --fast --cache-directory ./.ts-cache node_modules/.bin/lb-sdk --wipe enabled apps/api/server/server.ts packages/admin-lb-sdk/src",
     "start": "cd apps/api && npm start",
     "test": "true",
     "precommit": "lint-staged",


### PR DESCRIPTION
use ts-node to run loopback/lb-sdk to generate angular sdk

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- #42 (to reference issues in the current repository)
- colmena/colmena#42 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
-->

<!--
Thanks to strongloop/loopback for this template
-->
